### PR TITLE
Undo Bootstrap's normalisation of anchor box-sizing to avoid conflict

### DIFF
--- a/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.coffee.erb
@@ -166,6 +166,7 @@ window.RecurringSelectDialog =
         url: "/recurring_select/translate",
         type: "POST",
         data: @current_rule.hash
+        dataType: "html"
         success: @summaryFetchSuccess
 
     summaryFetchSuccess: (data) =>

--- a/app/assets/stylesheets/recurring_select.css.scss.erb
+++ b/app/assets/stylesheets/recurring_select.css.scss.erb
@@ -29,8 +29,25 @@ select {
 }
 
 .rs_dialog_holder { position:fixed; left:0px; right:0px; top:0px; bottom:0px; padding-left:50%; background-color:rgba(255,255,255,0.2); z-index:50;
-  .rs_dialog { background-color:#f6f6f6; border:1px solid #acacac; @include shadows(1px, 3px, 8px, rgba(0,0,0,0.25)); @include rounded_corners(7px);
-              display:inline-block; min-width:200px; margin-left:-125px; overflow:hidden; position:relative;
+  .rs_dialog {
+    background-color:#f6f6f6;
+    border:1px solid #acacac;
+    @include shadows(1px, 3px, 8px, rgba(0,0,0,0.25));
+    @include rounded_corners(7px);
+    display:inline-block;
+    min-width:200px;
+    margin-left:-125px;
+    overflow:hidden;
+    position:relative;
+
+    // Undo Bootstrap's normalisation of box sizing to avoid conflict
+    // http://getbootstrap.com/getting-started/#third-parties
+    a {
+      -webkit-box-sizing: content-box;
+      -moz-box-sizing: content-box;
+      box-sizing: content-box;
+    }
+
     .rs_dialog_content { padding:10px;
       h1 { font-size:16px; padding:0px; margin:0 0 10px 0;
         a {float:right; display:inline-block; height:16px; width:16px; background-image:url(<%=asset_path "recurring_select/cancel.png"%>); background-position:center; background-repeat:no-repeat;}

--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -29,13 +29,11 @@ module RecurringSelectHelper
       options_array = []
       blank_option_label = options[:blank_label] || I18n.t("recurring_select.not_recurring")
       blank_option = [blank_option_label, "null"]
-      separator = [I18n.t("recurring_select.or"), {:disabled => true}]
 
       if default_schedules.blank?
         if currently_selected_rule.present?
           options_array << blank_option if options[:allow_blank]
           options_array << ice_cube_rule_to_option(currently_selected_rule)
-          options_array << separator
           options_array << [I18n.t("recurring_select.change_schedule"), "custom"]
         else
           options_array << blank_option
@@ -55,7 +53,6 @@ module RecurringSelectHelper
           custom_label = [I18n.t("recurring_select.custom_schedule"), "custom"]
         end
 
-        options_array << separator
         options_array << custom_label
       end
 

--- a/lib/recurring_select/version.rb
+++ b/lib/recurring_select/version.rb
@@ -1,3 +1,3 @@
 module RecurringSelect
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/recurring_select.gemspec
+++ b/recurring_select.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.2"
   s.add_dependency "jquery-rails", ">= 3.0"
-  s.add_dependency "ice_cube", ">= 0.11"
+  s.add_dependency "ice_cube", ">= 0.12"
   s.add_dependency "sass-rails", ">= 3.1"
   s.add_dependency "coffee-rails", ">= 3.1"
 


### PR DESCRIPTION
The styling of the schedule setting widget was being broken by Bootstrap's normalisation of the box-sizing attribute of elements. In [the Bootstrap docs](http://getbootstrap.com/getting-started/#third-parties) they cover this and show various options for fixing it.

As only anchor elements were being affected I only applied the fix to them—this fixes the issue for me when using Bootstrap 3, and a quick test without Bootstrap loaded shows no change from the default look.

The styling problem I observed looks to be the same or very similar to that of when you integrate it with Foundation (Issue https://github.com/GetJobber/recurring_select/issues/49) so perhaps this fix will also help there.
