### PR TITLE
Fixing display issue when using this gem with bootstrap

### DIFF
--- a/app/assets/stylesheets/recurring_select.css.scss.erb
+++ b/app/assets/stylesheets/recurring_select.css.scss.erb
@@ -53,7 +53,7 @@ select {
 
         .rs_calendar_day, .rs_calendar_week {
           width:155px;
-          a {display:inline-block; text-align:center; width:15px; padding:5px 3px; font-size:12px; border-style:solid; border-color:#ccc; border-width:1px 1px 1px 1px; margin:-1px 0 0 -1px; line-height:10px; background-color:#fff; font-weight:bold;
+          a {display:inline-block; text-align:center; width:15px; padding:5px 3px; font-size:12px; border-style:solid; border-color:#ccc; border-width:1px 1px 1px 1px; margin:-1px 0 0 -1px; line-height:10px; background-color:#fff; font-weight:bold; box-sizing: content-box;
             &.selected {background-color:#89a; color:#fff; @include gradiant(#9ab, #789); @include inset_shadows(0px, 1px, 2px, rgba(0,0,0,0.2)); text-shadow:0 1px 1px #333;}
             &:hover { cursor:pointer; background-color:#dde;}
           }


### PR DESCRIPTION
Twitter-bootstrap adds this style, which stuffs up the layout

```
*,
*:before,
*:after {
  -webkit-box-sizing: border-box;
  -moz-box-sizing: border-box;
  box-sizing: border-box;
}
```
