### PR TITLE
Fix a bug in `dirty_hash_to_rule`

### DIFF
--- a/lib/recurring_select.rb
+++ b/lib/recurring_select.rb
@@ -7,14 +7,15 @@ module RecurringSelect
     if params.is_a? IceCube::Rule
       params
     else
-      if params.is_a?(String)
-        params = JSON.parse(params)
+      params = JSON.parse(params, quirks_mode: true) if params.is_a?(String)
+      if params.nil?
+        nil
+      else
+        params = params.symbolize_keys
+        rules_hash = filter_params(params)
+        IceCube::Rule.from_hash(rules_hash)
       end
 
-      params = params.symbolize_keys
-      rules_hash = filter_params(params)
-
-      IceCube::Rule.from_hash(rules_hash)
     end
   end
 


### PR DESCRIPTION
Make `dirty_hash_to_rule` capable of handling "null" as input, which is the default when 'No recurrence' is selected in the drop-down.