### PR TITLE
Rails 5 fix for undefined method `select_recurring`

### DIFF
--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -2,13 +2,13 @@ require "ice_cube"
 
 module RecurringSelectHelper
   module FormHelper
-    if Rails::VERSION::MAJOR == 4
-      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
-        RecurringSelectTag.new(object, method, self, default_schedules, options, html_options).render
-      end
-    elsif Rails::VERSION::MAJOR == 3
+    if Rails::VERSION::MAJOR == 3
       def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
         InstanceTag.new(object, method, self, options.delete(:object)).to_recurring_select_tag(default_schedules, options, html_options)
+      end
+    else
+      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
+        RecurringSelectTag.new(object, method, self, default_schedules, options, html_options).render
       end
     end
   end

--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -2,17 +2,17 @@ require "ice_cube"
 
 module RecurringSelectHelper
   module FormHelper
-    if Rails::VERSION::MAJOR == 3
-      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
-        InstanceTag.new(object, method, self, options.delete(:object)).to_recurring_select_tag(default_schedules, options, html_options)
-      end
-    else
+    if Rails::VERSION::MAJOR == 4 || Rails::VERSION::MAJOR == 5
       def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
         RecurringSelectTag.new(object, method, self, default_schedules, options, html_options).render
       end
+    elsif Rails::VERSION::MAJOR == 3
+      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
+        InstanceTag.new(object, method, self, options.delete(:object)).to_recurring_select_tag(default_schedules, options, html_options)
+      end
     end
   end
-
+  
   module FormBuilder
     def select_recurring(method, default_schedules = nil, options = {}, html_options = {})
       if !@template.respond_to?(:select_recurring)


### PR DESCRIPTION
After Rails 5 upgrade, gem stopped working with this error:
ActionView::Template::Error (undefined method `select_recurring' for #<#<Class:0x007fa3ae96a600>:0x007fa3ae9681c0>).
at this line
`= f.select_recurring :current_custom_rule,  []`

I added this quick fix to make this method available for rails 5.
If you can release a version with this fix i will be able to use this gem again from 'rubygems.org'

