### PR TITLE
dont set value "null" for not recurring events

### DIFF
--- a/app/assets/javascripts/recurring_select.js.coffee
+++ b/app/assets/javascripts/recurring_select.js.coffee
@@ -39,8 +39,9 @@ methods =
     @.trigger "recurring_select:save"
 
   current_rule: ->
+    initialValueHash = @data("initial-value-hash")
     str:  @data("initial-value-str")
-    hash: $.parseJSON(@data("initial-value-hash"))
+    hash: if initialValueHash? && initialValueHash != "" then $.parseJSON(initialValueHash) else null
 
   cancel: ->
     @val @data("initial-value-hash")

--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -28,7 +28,7 @@ module RecurringSelectHelper
 
       options_array = []
       blank_option_label = options[:blank_label] || I18n.t("recurring_select.not_recurring")
-      blank_option = [blank_option_label, "null"]
+      blank_option = [blank_option_label, ""]
       separator = [I18n.t("recurring_select.or"), {:disabled => true}]
 
       if default_schedules.blank?

--- a/lib/recurring_select.rb
+++ b/lib/recurring_select.rb
@@ -41,7 +41,7 @@ module RecurringSelect
   private
 
   def self.filter_params(params)
-    params.reject!{|key, value| value.blank? || value=="null" }
+    params.reject!{|key, value| value.blank? }
 
     params[:interval] = params[:interval].to_i if params[:interval]
     params[:week_start] = params[:week_start].to_i if params[:week_start]

--- a/spec/app/helpers/recurring_select_helper_spec.rb
+++ b/spec/app/helpers/recurring_select_helper_spec.rb
@@ -11,9 +11,9 @@ describe RecurringSelectHelper do
       subject = FromTester.new
       subject.should_receive(:options_for_select).with(
         [
-          ['- not recurring -', 'null'],
+          ['- not recurring -', ''],
           ['Set schedule...', 'custom']
-        ], 'null'
+        ], ''
       )
       subject.recurring_options_for_select
     end
@@ -38,7 +38,7 @@ describe RecurringSelectHelper do
           ["Monthly", IceCube::Rule.monthly.to_hash.to_json],
           ['or', {:disabled => true}],
           ['Custom schedule...', 'custom']
-        ], 'null'
+        ], ''
       )
       subject.recurring_options_for_select(nil, [IceCube::Rule.weekly, IceCube::Rule.monthly])
     end
@@ -47,7 +47,7 @@ describe RecurringSelectHelper do
       subject = FromTester.new
       subject.should_receive(:options_for_select).with(
         [
-          ["- not recurring -", 'null'],
+          ["- not recurring -", ''],
           ["different", 1],
           ["Weekly", IceCube::Rule.weekly.to_hash.to_json],
           ['or', {:disabled => true}],


### PR DESCRIPTION
`RecurringSelect.is_valid_rule?('null')` returns `true` but `RecurringSelect.dirty_hash_to_rule('null')` returns `nil`. It would be easier IMO to use a empty value for not recurring events so that `RecurringSelect.is_valid_rule?` returns false.