### PR TITLE
Rails 5.2 compatibility

### DIFF
--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -114,7 +114,11 @@ module RecurringSelectHelper
       end
 
       def render
-        option_tags = add_options(recurring_options_for_select(value(object), @default_schedules, @options), @options, value(object))
+        if Rails::VERSION::STRING >= '5.2' && defined?(Ransack) # Ransack monkey-patch breaks the normal value(object) helper in 5.2
+          option_tags = add_options(recurring_options_for_select(value, @default_schedules, @options), @options, value)
+        else
+          option_tags = add_options(recurring_options_for_select(value(object), @default_schedules, @options), @options, value(object))
+        end
         select_content_tag(option_tags, @options, @html_options)
       end
     end

--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -114,7 +114,7 @@ module RecurringSelectHelper
       end
 
       def render
-        if Rails::VERSION::STRING >= '5.2' && defined?(Ransack) # Ransack monkey-patch breaks the normal value(object) helper in 5.2
+        if Rails::VERSION::STRING >= '5.2'
           option_tags = add_options(recurring_options_for_select(value, @default_schedules, @options), @options, value)
         else
           option_tags = add_options(recurring_options_for_select(value(object), @default_schedules, @options), @options, value(object))

--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -2,13 +2,13 @@ require "ice_cube"
 
 module RecurringSelectHelper
   module FormHelper
-    if Rails::VERSION::MAJOR == 4
-      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
-        RecurringSelectTag.new(object, method, self, default_schedules, options, html_options).render
-      end
-    elsif Rails::VERSION::MAJOR == 3
+    if Rails::VERSION::MAJOR == 3
       def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
         InstanceTag.new(object, method, self, options.delete(:object)).to_recurring_select_tag(default_schedules, options, html_options)
+      end
+    else
+      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
+        RecurringSelectTag.new(object, method, self, default_schedules, options, html_options).render
       end
     end
   end

--- a/app/helpers/recurring_select_helper.rb
+++ b/app/helpers/recurring_select_helper.rb
@@ -2,17 +2,17 @@ require "ice_cube"
 
 module RecurringSelectHelper
   module FormHelper
-    if Rails::VERSION::MAJOR == 3
-      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
-        InstanceTag.new(object, method, self, options.delete(:object)).to_recurring_select_tag(default_schedules, options, html_options)
-      end
-    else
+    if Rails::VERSION::MAJOR == 4 || Rails::VERSION::MAJOR == 5
       def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
         RecurringSelectTag.new(object, method, self, default_schedules, options, html_options).render
       end
+    elsif Rails::VERSION::MAJOR == 3
+      def select_recurring(object, method, default_schedules = nil, options = {}, html_options = {})
+        InstanceTag.new(object, method, self, options.delete(:object)).to_recurring_select_tag(default_schedules, options, html_options)
+      end
     end
   end
-
+  
   module FormBuilder
     def select_recurring(method, default_schedules = nil, options = {}, html_options = {})
       if !@template.respond_to?(:select_recurring)

--- a/lib/recurring_select/version.rb
+++ b/lib/recurring_select/version.rb
@@ -1,3 +1,3 @@
 module RecurringSelect
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
If anyone is still maintaining this, I made some changes on @sahild's existing changes to allow it to work with some changes for `TagHelper::Base` in Rails 5.2.

Unlike the other PR for this, this is as minimally intrusive a change as possible.  Depends on the preference of the maintainers.