### PR TITLE
Fix for sprockets 4

### DIFF
--- a/app/assets/javascripts/recurring_select.js.coffee
+++ b/app/assets/javascripts/recurring_select.js.coffee
@@ -1,5 +1,5 @@
-//= require recurring_select_dialog
-//= require_self
+#= require recurring_select_dialog
+#= require_self
 
 $ = jQuery
 $ ->

--- a/lib/recurring_select/engine.rb
+++ b/lib/recurring_select/engine.rb
@@ -2,7 +2,6 @@ module RecurringSelect
   class Engine < Rails::Engine
     
     initializer "recurring_select.extending_form_builder" do |app|
-    # config.to_prepare do
       ActionView::Helpers::FormHelper.send(:include, RecurringSelectHelper::FormHelper)
       ActionView::Helpers::FormOptionsHelper.send(:include, RecurringSelectHelper::FormOptionsHelper)
       ActionView::Helpers::FormBuilder.send(:include, RecurringSelectHelper::FormBuilder)


### PR DESCRIPTION
Sprockets 4 throws errors when used with this gem due to a coffeescript file using javascript-style directives. This changes them to be coffeescript-style instead.