### PR TITLE
updated add_default_name_and_id bug

### DIFF
--- a/lib/helpers/recurring_select_helper.rb
+++ b/lib/helpers/recurring_select_helper.rb
@@ -100,6 +100,7 @@ module RecurringSelectHelper
       @method_name = method.to_s
       @object_name = object.to_s
       @html_options = recurring_select_html_options(html_options)
+      @template_object = template_object
       add_default_name_and_id(@html_options)
 
       super(object, method, template_object, options)

--- a/lib/recurring_select/version.rb
+++ b/lib/recurring_select/version.rb
@@ -1,3 +1,3 @@
 module RecurringSelect
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
after upgrading to rails 7, the recurring_select gem began to report an error when using the select_recurring method.  It turns out that the newer version of rails requires the @template_object instance variable to be explicitly set to the value of the local variable.  