### PR TITLE
JOB-114319 Fix zero value option bug

### DIFF
--- a/app/assets/javascripts/recurring_select_dialog.js.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.erb
@@ -77,7 +77,7 @@ class RecurringSelectDialog {
   freqInit() {
     this.freq_select = this.outer_holder.querySelector(".rs_frequency");
     const rule_type = this.current_rule.hash && this.current_rule.hash.rule_type
-    if (this.current_rule.hash != null && rule_type != null) {
+    if (this.current_rule.hash != null && rule_type) {
       if (rule_type.search(/Weekly/) !== -1) {
         this.freq_select.selectedIndex = 1
         this.initWeeklyOptions();

--- a/app/assets/javascripts/recurring_select_dialog.js.erb
+++ b/app/assets/javascripts/recurring_select_dialog.js.erb
@@ -77,7 +77,7 @@ class RecurringSelectDialog {
   freqInit() {
     this.freq_select = this.outer_holder.querySelector(".rs_frequency");
     const rule_type = this.current_rule.hash && this.current_rule.hash.rule_type
-    if (this.current_rule.hash != null && rule_type) {
+    if (rule_type) {
       if (rule_type.search(/Weekly/) !== -1) {
         this.freq_select.selectedIndex = 1
         this.initWeeklyOptions();


### PR DESCRIPTION
When switching from an option with value `0` to another option, a Javascript error is thrown:
![image](https://github.com/user-attachments/assets/e5c6be17-6dd2-43f1-8c80-74c63ab7a332)

The error occurs in `freqInit()` when the `current_rule.hash` is `0`.
<img width="648" alt="image" src="https://github.com/user-attachments/assets/f98854db-de92-49a7-af73-8108d25b5a1b" />


```Javascript
const rule_type = this.current_rule.hash && this.current_rule.hash.rule_type

// in this case is equivalent to:
const rule_type = 0 && undefined

// zero is "falsy" and Javascript returns the first "falsy" value that it finds so:
const rule_type = 0
```

The following line:
```Javascript
if (this.current_rule.hash != null && rule_type != null)

// becomes:
if (0 != null && 0 != null)
```
Which is `true`. To fix this, I've updated it to check that `rule_type` is "truthy".
```Javascript
if (rule_type)
```